### PR TITLE
Update .gitignore file with .eslintcache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
#### What’s this PR do?
- Updates `.gitignore` to ignore `.eslintcache`

#### Where should the reviewer start?
- In `.gitignore`

#### How should this be manually tested?
- Doesn't need to be tested, but running `git status` will no longer show `.eslintcache`

#### Any background context you want to provide?
- Couldn't pull down from main on different machines

#### What are the relevant tickets?
- Closes #3 